### PR TITLE
project_path and service_id tags + Println to build log checks for isLoggable Fine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.20.3-SNAPSHOT</version>
+    <version>1.20.3-custom-build-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -162,7 +162,7 @@ public class InfluxDbPublicationService {
     public void perform(Run<?, ?> build, TaskListener listener) {
 
         // Logging
-        listener.getLogger().println("[InfluxDB Plugin] Collecting data for publication in InfluxDB...");
+        printIfFineLoggable(listener, "[InfluxDB Plugin] Collecting data for publication in InfluxDB...");
 
         // Renderer to use for the metrics
         MeasurementRenderer<Run<?, ?>> measurementRenderer = new ProjectNameRenderer(customPrefix, customProjectName);
@@ -176,7 +176,7 @@ public class InfluxDbPublicationService {
 
         CustomDataPointGenerator cdGen = new CustomDataPointGenerator(measurementRenderer, customPrefix, build, timestamp, customData, customDataTags, measurementName, replaceDashWithUnderscore);
         if (cdGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
+            printIfFineLoggable(listener, "[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdGen, listener);
         } else {
             logger.log(Level.FINE, "Data source empty: Custom Data");
@@ -184,7 +184,7 @@ public class InfluxDbPublicationService {
 
         CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, timestamp, customDataMap, customDataMapTags, replaceDashWithUnderscore);
         if (cdmGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
+            printIfFineLoggable(listener, "[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);
         } else {
             logger.log(Level.FINE, "Data source empty: Custom Data Map");
@@ -193,7 +193,7 @@ public class InfluxDbPublicationService {
         try {
             CoberturaPointGenerator cGen = new CoberturaPointGenerator(measurementRenderer, customPrefix, build, timestamp, replaceDashWithUnderscore);
             if (cGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
+                printIfFineLoggable(listener, "[InfluxDB Plugin] Cobertura data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, cGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
@@ -203,7 +203,7 @@ public class InfluxDbPublicationService {
         try {
             RobotFrameworkPointGenerator rfGen = new RobotFrameworkPointGenerator(measurementRenderer, customPrefix, build, timestamp, replaceDashWithUnderscore);
             if (rfGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Robot Framework data found. Writing to InfluxDB...");
+                printIfFineLoggable(listener, "[InfluxDB Plugin] Robot Framework data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, rfGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
@@ -213,7 +213,7 @@ public class InfluxDbPublicationService {
         try {
             JacocoPointGenerator jacoGen = new JacocoPointGenerator(measurementRenderer, customPrefix, build, timestamp, replaceDashWithUnderscore);
             if (jacoGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
+                printIfFineLoggable(listener, "[InfluxDB Plugin] Jacoco data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, jacoGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
@@ -223,7 +223,7 @@ public class InfluxDbPublicationService {
         try {
             PerformancePointGenerator perfGen = new PerformancePointGenerator(measurementRenderer, customPrefix, build, timestamp, replaceDashWithUnderscore);
             if (perfGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
+                printIfFineLoggable(listener, "[InfluxDB Plugin] Performance data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, perfGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
@@ -232,7 +232,7 @@ public class InfluxDbPublicationService {
 
         SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(measurementRenderer, customPrefix, build, timestamp, listener, replaceDashWithUnderscore);
         if (sonarGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
+            printIfFineLoggable(listener, "[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, sonarGen, listener);
         } else {
             logger.log(Level.FINE, "Plugin skipped: SonarQube");
@@ -241,7 +241,7 @@ public class InfluxDbPublicationService {
 
         ChangeLogPointGenerator changeLogGen = new ChangeLogPointGenerator(measurementRenderer, customPrefix, build, timestamp, replaceDashWithUnderscore);
         if (changeLogGen.hasReport()) {
-            listener.getLogger().println("[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
+            printIfFineLoggable(listener, "[InfluxDB Plugin] Git ChangeLog data found. Writing to InfluxDB...");
             addPoints(pointsToWrite, changeLogGen, listener);
         } else {
             logger.log(Level.FINE, "Data source empty: Change Log");
@@ -250,7 +250,7 @@ public class InfluxDbPublicationService {
         try {
             PerfPublisherPointGenerator perfPublisherGen = new PerfPublisherPointGenerator(measurementRenderer, customPrefix, build, timestamp, replaceDashWithUnderscore);
             if (perfPublisherGen.hasReport()) {
-                listener.getLogger().println("[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
+                printIfFineLoggable(listener, "[InfluxDB Plugin] PerfPublisher data found. Writing to InfluxDB...");
                 addPoints(pointsToWrite, perfPublisherGen, listener);
             }
         } catch (NoClassDefFoundError ignore) {
@@ -264,7 +264,7 @@ public class InfluxDbPublicationService {
             // write to jenkins logger
             logger.log(Level.FINE, logMessage);
             // write to jenkins console
-            listener.getLogger().println(logMessage);
+            printIfFineLoggable(listener, logMessage);
             // connect to InfluxDB
             InfluxDB influxDB = Strings.isNullOrEmpty(selectedTarget.getUsername()) ?
                     InfluxDBFactory.connect(selectedTarget.getUrl()) :
@@ -274,14 +274,14 @@ public class InfluxDbPublicationService {
         }
 
         // We're done
-        listener.getLogger().println("[InfluxDB Plugin] Completed.");
+        printIfFineLoggable(listener, "[InfluxDB Plugin] Completed.");
     }
 
     private void addPoints(List<Point> pointsToWrite, PointGenerator generator, TaskListener listener) {
         try {
             pointsToWrite.addAll(Arrays.asList(generator.generate()));
         } catch (Exception e) {
-            listener.getLogger().println("[InfluxDB Plugin] Failed to collect data. Ignoring Exception:" + e);
+            printIfFineLoggable(listener, "[InfluxDB Plugin] Failed to collect data. Ignoring Exception:" + e);
         }
     }
 
@@ -304,6 +304,12 @@ public class InfluxDbPublicationService {
                 //Exceptions not exposed by configuration. Just log and ignore.
                 logger.log(Level.WARNING, "Could not report to InfluxDB. Ignoring Exception.", e);
             }
+        }
+    }
+
+    private void printIfFineLoggable(TaskListener listener, String s) {
+        if (logger.isLoggable(Level.FINE)) {
+            listener.getLogger().println(s);
         }
     }
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -47,6 +47,7 @@ public abstract class AbstractPointGenerator implements PointGenerator {
             builder.tag(CUSTOM_PREFIX, this.replaceDashWithUnderscore ? measurementName(customPrefix) : customPrefix);
 
         builder.tag(PROJECT_NAME, projectTagName);
+        builder.tag(PROJECT_PATH, build.getParent().getRelativeNameFrom(Jenkins.getInstance()));
 
         return builder;
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -127,6 +127,15 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             point.tag(tagMap);
         }
 
+        try {
+            String serviceId = build.getEnvironment(listener).get("SERVICE_ID");
+            if (serviceId != null) {
+                point.tag("service_id", serviceId);
+            }
+        } catch (InterruptedException | IOException e) {
+            // handle
+        }
+
         return new Point[] {point.build()};
     }
 


### PR DESCRIPTION
Change in logging to be dependent on log level, hiding unnecessary logging when not needed.
Adding tags:

- project_path based on info available in fields

- service_id based on ENV added in alfred

Related to: https://github.com/smartrecruiters/jenkins/pull/230

@smartrecruiters/core-team 


